### PR TITLE
Implement ShareTrip screen

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
-BACKEND_URL=http://<URL>:<PORT>/graphql
+BACKEND_URL=https://<URL>:<PORT>/graphql
+INVITATION_BASE_URL=https://<URL>/ # Note: the trailing slash is required when specifying a URL

--- a/App.tsx
+++ b/App.tsx
@@ -24,7 +24,7 @@ const Stack = createStackNavigator();
 export default function App(): JSX.Element {
     const { t } = useTranslation();
     const navigationRef = useRef<NavigationContainerRef>(null);
-    const replace = (name: string, params: any) => { //eslint-disable-line
+    const replace = (name: string, params: any) => {
         navigationRef.current?.dispatch(StackActions.replace(name, params));
     };
     const { getCurrentUser } = useCurrentAuthUser();

--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,3 @@
-import React, { useRef, useEffect, useState } from "react";
 import {
     NavigationContainer,
     NavigationContainerRef,
@@ -6,15 +5,17 @@ import {
 } from "@react-navigation/native";
 import { createStackNavigator } from "@react-navigation/stack";
 import { StatusBar } from "expo-status-bar";
+import React, { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import ApolloConnection from "./src/components/ApolloConnection/ApolloConnection";
+import SvgLogo from "./src/components/SvgLogo";
+import useCurrentAuthUser from "./src/hooks/useCurrentAuthUser";
 import Login from "./src/screens/Login/Login";
 import Register from "./src/screens/Register/Register";
+import ShareTrip from "./src/screens/ShareTrip/ShareTrip";
 import TripsDashboard from "./src/screens/TripsDashboard/TripsDashboard";
 import i18n from "./src/services/i18n";
-import useCurrentAuthUser from "./src/hooks/useCurrentAuthUser";
-import SvgLogo from "./src/components/SvgLogo";
 import { AddTrip } from "./src/screens/AddTrip/AddTrip";
 //init i18n
 i18n;
@@ -30,18 +31,19 @@ export default function App(): JSX.Element {
     const [initialRoute, setInitialRoute] = useState("");
 
     useEffect(() => {
-        async function loadInitalRoute() {
+        async function loadInitialRoute() {
             const result = await getCurrentUser();
             const route = result != null ? "Dashboard" : "Login";
             console.log("Initial route? " + route);
             setInitialRoute(route);
         }
-        loadInitalRoute();
+
+        loadInitialRoute();
     }, []);
     return (
         <SafeAreaProvider>
             <StatusBar style="dark" backgroundColor="white" />
-            {(initialRoute === "" && <SvgLogo></SvgLogo>) || (
+            {(initialRoute === "" && <SvgLogo />) || (
                 <NavigationContainer ref={navigationRef}>
                     <ApolloConnection navigationFn={replace}>
                         <Stack.Navigator initialRouteName={initialRoute}>
@@ -67,6 +69,13 @@ export default function App(): JSX.Element {
                                 component={AddTrip}
                                 options={{
                                     title: t("screens.add_trip.title"),
+                                }}
+                            />
+                            <Stack.Screen
+                                name="ShareTrip"
+                                component={ShareTrip}
+                                options={{
+                                    title: t("screens.shareTrip.title"),
                                 }}
                             />
                         </Stack.Navigator>

--- a/app.json
+++ b/app.json
@@ -11,6 +11,7 @@
             "resizeMode": "contain",
             "backgroundColor": "#ffffff"
         },
+        "scheme": "vacatius",
         "updates": {
             "fallbackToCacheTimeout": 0
         },

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
+    "start:clear": "expo r -c",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",

--- a/src/components/ScreenHeader.tsx
+++ b/src/components/ScreenHeader.tsx
@@ -12,7 +12,7 @@ const ScreenHeader: React.FC<ScreenHeaderProps> = (
     <View>
         <Header
             placement="left"
-            centerComponent={<Text h1>{props.screenTitle}</Text>}
+            leftComponent={<Text h1>{props.screenTitle}</Text>}
             rightComponent={
                 <TouchableOpacity>
                     <Avatar
@@ -32,7 +32,6 @@ const styles = StyleSheet.create({
     header: {
         backgroundColor: "transparent",
         color: "black",
-        marginLeft: -15, // TODO - Find a way how to not hard code this value
     },
     avatar: {
         backgroundColor: "red",

--- a/src/get-environment.ts
+++ b/src/get-environment.ts
@@ -1,15 +1,17 @@
+import { BACKEND_URL, INVITATION_BASE_URL } from "@env";
 import Constants from "expo-constants";
-import { BACKEND_URL } from "@env";
 
 export function getEnvironment() {
     const { releaseChannel } = Constants.manifest;
     const develop = {
         envName: "DEVELOPMENT",
         backendUrl: BACKEND_URL,
+        invitationBaseUrl: INVITATION_BASE_URL,
     };
     const production = {
         envName: "PRODUCTION",
         backendUrl: BACKEND_URL,
+        invitationBaseUrl: INVITATION_BASE_URL,
     };
 
     if (releaseChannel === undefined) {

--- a/src/graphql.schema.json
+++ b/src/graphql.schema.json
@@ -190,6 +190,30 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "activityReactions",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ActivityReaction",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -221,6 +245,158 @@
         "inputFields": null,
         "interfaces": null,
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ActivityReaction",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": "ID of the activity reaction",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "activityReactionType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ActivityReactionType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "activity",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Activity",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "addedByUser",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ActivityReactionType",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "LIKE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DISLIKE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -304,6 +480,49 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CreateActivityReactionInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "activityId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "activityReactionType",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ActivityReactionType",
+                "ofType": null
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -1465,6 +1684,105 @@
             "deprecationReason": null
           },
           {
+            "name": "createActivityReaction",
+            "description": null,
+            "args": [
+              {
+                "name": "data",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CreateActivityReactionInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ActivityReaction",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updateActivityReaction",
+            "description": null,
+            "args": [
+              {
+                "name": "data",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "UpdateActivityReactionInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ActivityReaction",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "removeActivityReaction",
+            "description": null,
+            "args": [
+              {
+                "name": "activityReactionId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ActivityReaction",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "createInvitation",
             "description": null,
             "args": [
@@ -1624,6 +1942,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "ActivityReaction",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "Invitation",
             "ofType": null
           },
@@ -1773,6 +2096,47 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "Activity",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "activityReactions",
+            "description": null,
+            "args": [
+              {
+                "name": "activityId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ActivityReaction",
                     "ofType": null
                   }
                 }
@@ -2704,6 +3068,49 @@
           },
           {
             "name": "activityId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "UpdateActivityReactionInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "activityReactionType",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ActivityReactionType",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "activityReactionId",
             "description": null,
             "type": {
               "kind": "NON_NULL",

--- a/src/screens/AddTrip/AddTrip.tsx
+++ b/src/screens/AddTrip/AddTrip.tsx
@@ -49,11 +49,18 @@ export const AddTrip = (props: Props): JSX.Element => {
             },
             refetchQueries: [refetchTripsQuery()],
         })
-            .then(() => {
+            .then((result) => {
                 console.log("Successfully created this trip");
                 navigation.reset({
                     index: 0,
-                    routes: [{ name: "Dashboard" }],
+                    routes: [
+                        {
+                            name: "ShareTrip",
+                            params: {
+                                trip: result.data?.createTrip,
+                            },
+                        },
+                    ],
                 });
             })
             .catch((e) => {

--- a/src/screens/ShareTrip/ShareTrip.tsx
+++ b/src/screens/ShareTrip/ShareTrip.tsx
@@ -52,7 +52,7 @@ export default function ShareTrip(props: Props): JSX.Element {
     const handleSystemShareSheet = async (invitationLink: string) => {
         try {
             let shareObject: ShareContent = {
-                title: t("androidShareSheetTitle"),
+                title: t("androidShareSheetTitle").toString(),
                 message: invitationLink,
             };
             // Only use url to properly display shareable content in iOS share sheet
@@ -77,7 +77,6 @@ export default function ShareTrip(props: Props): JSX.Element {
                 leftComponent={<Text h2>{trip.name}</Text>}
                 rightComponent={
                     <Avatar
-                        // TODO - Add proper icon once backend provides one
                         rounded
                         size="medium"
                         icon={{
@@ -85,7 +84,7 @@ export default function ShareTrip(props: Props): JSX.Element {
                             type: "font-awesome-5",
                         }}
                         containerStyle={{ backgroundColor: "black" }}
-                    />
+                    /> // TODO - Add proper icon once backend provides one
                 }
             />
             <ScrollView style={styles.scrollView}>

--- a/src/screens/ShareTrip/ShareTrip.tsx
+++ b/src/screens/ShareTrip/ShareTrip.tsx
@@ -1,3 +1,4 @@
+import { RouteProp } from "@react-navigation/core";
 import { StackNavigationProp } from "@react-navigation/stack";
 import React from "react";
 import { useTranslation } from "react-i18next";
@@ -6,22 +7,27 @@ import { Avatar, Button, Header, Text } from "react-native-elements";
 import SvgLogo from "../../components/SvgLogo";
 import RootStackParamList from "../../types/RootStackParamList";
 
-type TripsDashboardScreenNavigationProp = StackNavigationProp<
+type ShareTripScreenNavigationProp = StackNavigationProp<
     RootStackParamList,
     "ShareTrip"
 >;
+type ShareTripScreenRouteProp = RouteProp<RootStackParamList, "ShareTrip">;
 
 type Props = {
-    navigation: TripsDashboardScreenNavigationProp;
+    navigation: ShareTripScreenNavigationProp;
+    route: ShareTripScreenRouteProp;
 };
 
-export default function ShareTrip(props: Props) {
+export default function ShareTrip(props: Props): JSX.Element {
     const { t } = useTranslation();
+    const trip = props.route.params.trip;
 
     const handleSystemShare = async () => {
         try {
             await Share.share({
-                message: "Test \nTest",
+                message:
+                    trip.name +
+                    (trip.description ? "\n" + trip.description : ""),
                 url: "https://example.com",
             });
         } catch (error) {
@@ -35,25 +41,22 @@ export default function ShareTrip(props: Props) {
             <Header
                 placement={"left"}
                 containerStyle={styles.header}
-                leftComponent={<Text h2>Roadtrip 2021</Text>}
+                leftComponent={<Text h2>{trip.name}</Text>}
                 rightComponent={
                     <Avatar
+                        // TODO - Add proper icon once backend provides one
                         rounded
                         size="medium"
                         icon={{
-                            // TODO - Replace
                             name: "umbrella-beach",
                             type: "font-awesome-5",
                         }}
-                        containerStyle={{ backgroundColor: "black" }} // TODO - Replace
+                        containerStyle={{ backgroundColor: "black" }}
                     />
                 }
             />
             <ScrollView style={styles.scrollView}>
-                <Text h4>
-                    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
-                    diam nonumy eirmod tempor invidunt ut
-                </Text>
+                {trip.description && <Text h4>{trip.description}</Text>}
                 <SvgLogo style={styles.logo} height={150} width={150} />
                 <Button
                     containerStyle={styles.btnContainer}
@@ -68,7 +71,11 @@ export default function ShareTrip(props: Props) {
                     title={t("screens.shareTrip.planTrip")}
                     titleStyle={styles.btnTextStyle}
                     // TODO - Redirect to trip itinerary screen
-                    onPress={() => console.log("TODO - Missing redirect")}
+                    onPress={() =>
+                        console.log(
+                            "TODO - Missing redirect to trip details screen"
+                        )
+                    }
                 />
                 <Button
                     containerStyle={{ marginTop: -10 }}

--- a/src/screens/ShareTrip/ShareTrip.tsx
+++ b/src/screens/ShareTrip/ShareTrip.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-native";
 import { Avatar, Button, Header, Text } from "react-native-elements";
 import SvgLogo from "../../components/SvgLogo";
+import { getEnvironment } from "../../get-environment";
 import RootStackParamList from "../../types/RootStackParamList";
 import { useCreateInvitationMutation } from "./types/create-invite.mutation";
 
@@ -31,8 +32,6 @@ export default function ShareTrip(props: Props): JSX.Element {
     const trip = props.route.params.trip;
     const [execute, { error, loading }] = useCreateInvitationMutation();
 
-    const invitationBaseUrl = "https://vacatius.com/invite/";
-
     const handleShare = () => {
         execute({
             variables: {
@@ -44,7 +43,7 @@ export default function ShareTrip(props: Props): JSX.Element {
             .then((result) => {
                 if (result.data?.createInvitation.id) {
                     handleSystemShareSheet(
-                        invitationBaseUrl +
+                        getEnvironment()?.invitationBaseUrl +
                             encodeURIComponent(result.data?.createInvitation.id)
                     );
                 }

--- a/src/screens/ShareTrip/ShareTrip.tsx
+++ b/src/screens/ShareTrip/ShareTrip.tsx
@@ -1,6 +1,7 @@
 import { RouteProp } from "@react-navigation/core";
 import { StackNavigationProp } from "@react-navigation/stack";
 import React from "react";
+import { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import {
     Platform,
@@ -52,7 +53,7 @@ export default function ShareTrip(props: Props): JSX.Element {
     const handleSystemShareSheet = async (invitationLink: string) => {
         try {
             let shareObject: ShareContent = {
-                title: t("androidShareSheetTitle").toString(),
+                title: t("screens.shareTrip.androidShareSheetTitle"),
                 message: invitationLink,
             };
             // Only use url to properly display shareable content in iOS share sheet

--- a/src/screens/ShareTrip/ShareTrip.tsx
+++ b/src/screens/ShareTrip/ShareTrip.tsx
@@ -1,0 +1,115 @@
+import { StackNavigationProp } from "@react-navigation/stack";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { ScrollView, Share, StyleSheet } from "react-native";
+import { Avatar, Button, Header, Text } from "react-native-elements";
+import SvgLogo from "../../components/SvgLogo";
+import RootStackParamList from "../../types/RootStackParamList";
+
+type TripsDashboardScreenNavigationProp = StackNavigationProp<
+    RootStackParamList,
+    "ShareTrip"
+>;
+
+type Props = {
+    navigation: TripsDashboardScreenNavigationProp;
+};
+
+export default function ShareTrip(props: Props) {
+    const { t } = useTranslation();
+
+    const handleSystemShare = async () => {
+        try {
+            await Share.share({
+                message: "Test \nTest",
+                url: "https://example.com",
+            });
+        } catch (error) {
+            // TODO - Notify user with error modal
+            console.error(error.message);
+        }
+    };
+
+    return (
+        <>
+            <Header
+                placement={"left"}
+                containerStyle={styles.header}
+                leftComponent={<Text h2>Roadtrip 2021</Text>}
+                rightComponent={
+                    <Avatar
+                        rounded
+                        size="medium"
+                        icon={{
+                            // TODO - Replace
+                            name: "umbrella-beach",
+                            type: "font-awesome-5",
+                        }}
+                        containerStyle={{ backgroundColor: "black" }} // TODO - Replace
+                    />
+                }
+            />
+            <ScrollView style={styles.scrollView}>
+                <Text h4>
+                    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
+                    diam nonumy eirmod tempor invidunt ut
+                </Text>
+                <SvgLogo style={styles.logo} height={150} width={150} />
+                <Button
+                    containerStyle={styles.btnContainer}
+                    buttonStyle={styles.shareBtn}
+                    title={t("screens.shareTrip.share")}
+                    titleStyle={styles.btnTextStyle}
+                    onPress={() => handleSystemShare()}
+                />
+                <Button
+                    containerStyle={styles.btnContainer}
+                    buttonStyle={styles.planTripBtn}
+                    title={t("screens.shareTrip.planTrip")}
+                    titleStyle={styles.btnTextStyle}
+                    // TODO - Redirect to trip itinerary screen
+                    onPress={() => console.log("TODO - Missing redirect")}
+                />
+                <Button
+                    containerStyle={{ marginTop: -10 }}
+                    buttonStyle={styles.backToDashboardBtn}
+                    title={t("screens.shareTrip.backToDashboard")}
+                    titleStyle={{ color: "black", fontSize: 20 }}
+                    onPress={() => props.navigation.replace("Dashboard")}
+                />
+            </ScrollView>
+        </>
+    );
+}
+
+const styles = StyleSheet.create({
+    header: {
+        backgroundColor: "transparent",
+        color: "black",
+    },
+    scrollView: {
+        paddingLeft: 15,
+        paddingRight: 15,
+    },
+    logo: {
+        alignSelf: "center",
+        marginTop: 30,
+        marginBottom: 40,
+    },
+    btnContainer: {
+        marginBottom: 15,
+    },
+    btnTextStyle: {
+        color: "black",
+        fontSize: 25,
+    },
+    shareBtn: {
+        backgroundColor: "#93C3FE",
+    },
+    planTripBtn: {
+        backgroundColor: "#BCE1B0",
+    },
+    backToDashboardBtn: {
+        backgroundColor: "transparent",
+    },
+});

--- a/src/screens/ShareTrip/ShareTrip.tsx
+++ b/src/screens/ShareTrip/ShareTrip.tsx
@@ -1,7 +1,6 @@
 import { RouteProp } from "@react-navigation/core";
 import { StackNavigationProp } from "@react-navigation/stack";
 import React from "react";
-import { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import {
     Platform,
@@ -43,9 +42,12 @@ export default function ShareTrip(props: Props): JSX.Element {
             },
         })
             .then((result) => {
-                handleSystemShareSheet(
-                    invitationBaseUrl + result.data?.createInvitation.id
-                );
+                if (result.data?.createInvitation.id) {
+                    handleSystemShareSheet(
+                        invitationBaseUrl +
+                            encodeURIComponent(result.data?.createInvitation.id)
+                    );
+                }
             })
             .catch((error) => console.error(error)); // TODO - Notify user with error modal
     };

--- a/src/screens/ShareTrip/create-invite.mutation.gql
+++ b/src/screens/ShareTrip/create-invite.mutation.gql
@@ -1,0 +1,11 @@
+mutation createInvitation($input: CreateInvitationInput!) {
+    createInvitation(data: $input) {
+        id
+        status
+        createdByUser {
+            displayName
+        }
+        acceptedUsersCount
+        tripId
+    }
+}

--- a/src/screens/ShareTrip/types/create-invite.mutation.ts
+++ b/src/screens/ShareTrip/types/create-invite.mutation.ts
@@ -1,0 +1,57 @@
+import * as Types from '../../../types.d';
+
+import { gql } from '@apollo/client';
+import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
+export type CreateInvitationMutationVariables = Types.Exact<{
+  input: Types.CreateInvitationInput;
+}>;
+
+
+export type CreateInvitationMutation = { createInvitation: { id: string, status: Types.InvitationStatus, acceptedUsersCount: number, tripId: string, createdByUser: { displayName: string } } };
+
+
+export const CreateInvitationDocument = gql`
+    mutation createInvitation($input: CreateInvitationInput!) {
+  createInvitation(data: $input) {
+    id
+    status
+    createdByUser {
+      displayName
+    }
+    acceptedUsersCount
+    tripId
+  }
+}
+    `;
+export type CreateInvitationMutationFn = Apollo.MutationFunction<CreateInvitationMutation, CreateInvitationMutationVariables>;
+
+/**
+ * __useCreateInvitationMutation__
+ *
+ * To run a mutation, you first call `useCreateInvitationMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateInvitationMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createInvitationMutation, { data, loading, error }] = useCreateInvitationMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useCreateInvitationMutation(baseOptions?: Apollo.MutationHookOptions<CreateInvitationMutation, CreateInvitationMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateInvitationMutation, CreateInvitationMutationVariables>(CreateInvitationDocument, options);
+      }
+export type CreateInvitationMutationHookResult = ReturnType<typeof useCreateInvitationMutation>;
+export type CreateInvitationMutationResult = Apollo.MutationResult<CreateInvitationMutation>;
+export type CreateInvitationMutationOptions = Apollo.BaseMutationOptions<CreateInvitationMutation, CreateInvitationMutationVariables>;
+export const namedOperations = {
+  Mutation: {
+    createInvitation: 'createInvitation'
+  }
+}

--- a/src/services/i18n.ts
+++ b/src/services/i18n.ts
@@ -86,6 +86,11 @@ export const resources = {
                     errors: {
                         noTripsFound: "No past trips found.",
                     },
+                shareTrip: {
+                    title: "Share a Trip",
+                    share: "Share with Friends",
+                    planTrip: "Plan Trip",
+                    backToDashboard: "Back to Dashboard",
                 },
             },
         },
@@ -151,6 +156,11 @@ export const resources = {
                     errors: {
                         noTripsFound: "Keine Reisen gefunden.",
                     },
+                shareTrip: {
+                    title: "Reise teilen",
+                    share: "Mit Freunden teilen",
+                    planTrip: "Reise planen",
+                    backToDashboard: "Zurück zum Dashboard",
                 },
             },
         },

--- a/src/services/i18n.ts
+++ b/src/services/i18n.ts
@@ -1,6 +1,6 @@
+import * as Localization from "expo-localization";
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
-import * as Localization from "expo-localization";
 
 export const resources = {
     en: {
@@ -92,6 +92,7 @@ export const resources = {
                     share: "Share with Friends",
                     planTrip: "Plan Trip",
                     backToDashboard: "Back to Dashboard",
+                    androidShareSheetTitle: "Share your Trip with Friends",
                 },
             },
         },
@@ -163,6 +164,7 @@ export const resources = {
                     share: "Mit Freunden teilen",
                     planTrip: "Reise planen",
                     backToDashboard: "Zurück zum Dashboard",
+                    androidShareSheetTitle: "Teile deine Reise mit Freunden",
                 },
             },
         },

--- a/src/services/i18n.ts
+++ b/src/services/i18n.ts
@@ -86,6 +86,7 @@ export const resources = {
                     errors: {
                         noTripsFound: "No past trips found.",
                     },
+                },
                 shareTrip: {
                     title: "Share a Trip",
                     share: "Share with Friends",
@@ -156,6 +157,7 @@ export const resources = {
                     errors: {
                         noTripsFound: "Keine Reisen gefunden.",
                     },
+                },
                 shareTrip: {
                     title: "Reise teilen",
                     share: "Mit Freunden teilen",

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -28,7 +28,25 @@ export type Activity = Node & {
   createdAt: Scalars['DateTime'];
   updatedAt: Scalars['DateTime'];
   deletedAt: Scalars['DateTime'];
+  activityReactions: Array<ActivityReaction>;
 };
+
+export type ActivityReaction = Node & {
+  __typename?: 'ActivityReaction';
+  /** ID of the activity reaction */
+  id: Scalars['ID'];
+  activityReactionType: ActivityReactionType;
+  activity: Activity;
+  addedByUser: User;
+  createdAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime'];
+  deletedAt: Scalars['DateTime'];
+};
+
+export enum ActivityReactionType {
+  Like = 'LIKE',
+  Dislike = 'DISLIKE'
+}
 
 export type CreateActivityInput = {
   routePointId: Scalars['String'];
@@ -37,6 +55,11 @@ export type CreateActivityInput = {
   linkToDetails?: Maybe<Scalars['String']>;
   startDate?: Maybe<Scalars['String']>;
   endDate?: Maybe<Scalars['String']>;
+};
+
+export type CreateActivityReactionInput = {
+  activityId: Scalars['String'];
+  activityReactionType: ActivityReactionType;
 };
 
 export type CreateInvitationInput = {
@@ -132,6 +155,9 @@ export type Mutation = {
   createActivity: Activity;
   updateActivity: Activity;
   removeActivity: MutationResult;
+  createActivityReaction: ActivityReaction;
+  updateActivityReaction: ActivityReaction;
+  removeActivityReaction: ActivityReaction;
   createInvitation: Invitation;
   updateInvitation: Invitation;
 };
@@ -212,6 +238,21 @@ export type MutationRemoveActivityArgs = {
 };
 
 
+export type MutationCreateActivityReactionArgs = {
+  data: CreateActivityReactionInput;
+};
+
+
+export type MutationUpdateActivityReactionArgs = {
+  data: UpdateActivityReactionInput;
+};
+
+
+export type MutationRemoveActivityReactionArgs = {
+  activityReactionId: Scalars['String'];
+};
+
+
 export type MutationCreateInvitationArgs = {
   data: CreateInvitationInput;
 };
@@ -238,6 +279,7 @@ export type Query = {
   tripRoutePoint: TripRoutePoint;
   user: User;
   activities: Array<Activity>;
+  activityReactions: Array<ActivityReaction>;
   invitation: Invitation;
   node?: Maybe<Node>;
 };
@@ -255,6 +297,11 @@ export type QueryTripRoutePointArgs = {
 
 export type QueryActivitiesArgs = {
   tripId: Scalars['String'];
+};
+
+
+export type QueryActivityReactionsArgs = {
+  activityId: Scalars['String'];
 };
 
 
@@ -362,6 +409,11 @@ export type UpdateActivityInput = {
   startDate?: Maybe<Scalars['String']>;
   endDate?: Maybe<Scalars['String']>;
   activityId: Scalars['String'];
+};
+
+export type UpdateActivityReactionInput = {
+  activityReactionType: ActivityReactionType;
+  activityReactionId: Scalars['String'];
 };
 
 export type UpdateInvitationInput = {

--- a/src/types/RootStackParamList.ts
+++ b/src/types/RootStackParamList.ts
@@ -1,8 +1,10 @@
+import { CreateTripMutation } from "../screens/AddTrip/types/add-trip.mutation";
+
 type RootStackParamList = {
     Login: undefined;
     Register: undefined;
     Dashboard: undefined;
-    ShareTrip: undefined;
+    ShareTrip: { trip: CreateTripMutation["createTrip"] };
 };
 
 export default RootStackParamList;

--- a/src/types/RootStackParamList.ts
+++ b/src/types/RootStackParamList.ts
@@ -2,6 +2,7 @@ type RootStackParamList = {
     Login: undefined;
     Register: undefined;
     Dashboard: undefined;
+    ShareTrip: undefined;
 };
 
 export default RootStackParamList;

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -1,3 +1,4 @@
-declare module '@env' {
+declare module "@env" {
     export const BACKEND_URL: string;
+    export const INVITATION_BASE_URL: string;
 }


### PR DESCRIPTION
This PR closes #9 by implementing a screen to share a newly created trip. The screen uses the system share sheet provided by the OS and no custom implementation.

As discussed in https://github.com/vacatius/mobile-app/issues/9#issuecomment-824139439, we will make use of the custom `vacatius://` scheme in combination with a website that redirects users to the app.

**Example:**
![IMG_2385](https://user-images.githubusercontent.com/22751730/115579802-cce95480-a2c6-11eb-8c17-a9ea10a6d921.PNG)
