### PR TITLE
User friendly error handling, make accordion header pressable, optical fixes

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,6 +9,7 @@ import { StatusBar } from "expo-status-bar";
 import React, { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { SafeAreaProvider } from "react-native-safe-area-context";
+import Toast from "react-native-toast-message";
 import ApolloConnection from "./src/components/ApolloConnection/ApolloConnection";
 import ScreenHeader from "./src/components/ScreenHeader";
 import SvgLogo from "./src/components/SvgLogo";
@@ -167,6 +168,12 @@ export default function App(): JSX.Element {
                     </ApolloConnection>
                 </NavigationContainer>
             )}
+            <Toast
+                ref={(ref) => Toast.setRef(ref)}
+                style={{
+                    height: 50,
+                }}
+            />
         </SafeAreaProvider>
     );
 }

--- a/App.tsx
+++ b/App.tsx
@@ -170,6 +170,7 @@ export default function App(): JSX.Element {
             )}
             <Toast
                 ref={(ref) => Toast.setRef(ref)}
+                topOffset={80}
                 style={{
                     height: 50,
                 }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
                 "react-native-reanimated": "~1.13.0",
                 "react-native-screens": "~2.15.2",
                 "react-native-svg": "12.1.1",
+                "react-native-toast-message": "^1.4.9",
                 "react-native-web": "~0.14.13",
                 "string-to-color": "^2.2.2",
                 "yup": "^0.32.9"
@@ -13305,6 +13306,14 @@
             "peerDependencies": {
                 "react": "*",
                 "react-native": ">=0.50.0"
+            }
+        },
+        "node_modules/react-native-toast-message": {
+            "version": "1.4.9",
+            "resolved": "https://registry.npmjs.org/react-native-toast-message/-/react-native-toast-message-1.4.9.tgz",
+            "integrity": "sha512-QhHzzsiymKpHEWz2nUKQjQMRuGN+/a8cOwDXJcz3TQFY03p20f6sJW9JKw3KkMfvWiUhGbApCPpNU6tHaAZ32w==",
+            "dependencies": {
+                "prop-types": "^15.7.2"
             }
         },
         "node_modules/react-native-vector-icons": {
@@ -28081,6 +28090,14 @@
             "requires": {
                 "css-select": "^2.1.0",
                 "css-tree": "^1.0.0-alpha.39"
+            }
+        },
+        "react-native-toast-message": {
+            "version": "1.4.9",
+            "resolved": "https://registry.npmjs.org/react-native-toast-message/-/react-native-toast-message-1.4.9.tgz",
+            "integrity": "sha512-QhHzzsiymKpHEWz2nUKQjQMRuGN+/a8cOwDXJcz3TQFY03p20f6sJW9JKw3KkMfvWiUhGbApCPpNU6tHaAZ32w==",
+            "requires": {
+                "prop-types": "^15.7.2"
             }
         },
         "react-native-vector-icons": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "react-native-reanimated": "~1.13.0",
         "react-native-screens": "~2.15.2",
         "react-native-svg": "12.1.1",
+        "react-native-toast-message": "^1.4.9",
         "react-native-web": "~0.14.13",
         "string-to-color": "^2.2.2",
         "yup": "^0.32.9"

--- a/src/components/ActivityGroupHeader.tsx
+++ b/src/components/ActivityGroupHeader.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { Pressable, StyleSheet, Text, View } from "react-native";
 import { Icon } from "react-native-elements";
 
 interface ActivityGroupHeaderProps {
@@ -19,38 +19,40 @@ export default function ActivityGroupHeader(
     props: ActivityGroupHeaderProps
 ): JSX.Element {
     return (
-        <View style={styles.container}>
-            <View style={styles.containerItemLeft}>
-                <Text numberOfLines={1} style={styles.title}>
-                    {props.title}
-                </Text>
+        <Pressable onPress={props.onOpen}>
+            <View style={styles.container}>
+                <View style={styles.containerItemLeft}>
+                    <Text numberOfLines={1} style={styles.title}>
+                        {props.title}
+                    </Text>
+                </View>
+                <View style={styles.containerItemRight}>
+                    <Icon
+                        name="pen"
+                        size={iconValues.size - 5}
+                        type="font-awesome-5"
+                        color={iconValues.blue}
+                        onPress={props.onEdit}
+                        style={styles.penIcon}
+                    />
+                    <Icon
+                        name="plus"
+                        size={iconValues.size}
+                        type="font-awesome-5"
+                        color={iconValues.blue}
+                        onPress={props.onAdd}
+                        style={styles.addIcon}
+                    />
+                    <Icon
+                        name={props.isOpen ? "chevron-up" : "chevron-down"}
+                        size={iconValues.size}
+                        type="font-awesome-5"
+                        color="black"
+                        onPress={props.onOpen}
+                    />
+                </View>
             </View>
-            <View style={styles.containerItemRight}>
-                <Icon
-                    name="pen"
-                    size={iconValues.size - 5}
-                    type="font-awesome-5"
-                    color={iconValues.blue}
-                    onPress={props.onEdit}
-                    style={styles.penIcon}
-                />
-                <Icon
-                    name="plus"
-                    size={iconValues.size}
-                    type="font-awesome-5"
-                    color={iconValues.blue}
-                    onPress={props.onAdd}
-                    style={styles.addIcon}
-                />
-                <Icon
-                    name={props.isOpen ? "chevron-up" : "chevron-down"}
-                    size={iconValues.size}
-                    type="font-awesome-5"
-                    color="black"
-                    onPress={props.onOpen}
-                />
-            </View>
-        </View>
+        </Pressable>
     );
 }
 

--- a/src/components/ActivityGroupHeader.tsx
+++ b/src/components/ActivityGroupHeader.tsx
@@ -48,7 +48,6 @@ export default function ActivityGroupHeader(
                         size={iconValues.size}
                         type="font-awesome-5"
                         color="black"
-                        onPress={props.onOpen}
                     />
                 </View>
             </View>

--- a/src/components/ApolloConnection/ApolloConnection.tsx
+++ b/src/components/ApolloConnection/ApolloConnection.tsx
@@ -117,7 +117,7 @@ export default function ApolloConnection(props: Props): JSX.Element {
             }
             if (networkError) {
                 Toast.show({
-                    text1: t("error.generic"),
+                    text1: t("error.network"),
                     text2: networkError.message,
                     type: "error",
                 });

--- a/src/components/ApolloConnection/ApolloConnection.tsx
+++ b/src/components/ApolloConnection/ApolloConnection.tsx
@@ -10,6 +10,8 @@ import { setContext } from "@apollo/client/link/context";
 import { onError } from "@apollo/client/link/error";
 import * as SecureStore from "expo-secure-store";
 import React from "react";
+import { useTranslation } from "react-i18next";
+import Toast from "react-native-toast-message";
 import { getEnvironment } from "../../get-environment";
 import SecureStorageItems from "../../types/SecureStorageItems";
 import { REFRESH_TOKEN_MUTATION } from "./refresh-token.mutation";
@@ -22,6 +24,8 @@ export default function ApolloConnection(props: Props): JSX.Element {
     // Initialize Apollo Client (Backend)
     let isRefreshing = false;
     let pendingRequests: any[] = []; // eslint-disable-line
+
+    const { t } = useTranslation();
 
     const resolvePendingRequests = (): void => {
         pendingRequests.map((callback) => callback());
@@ -51,10 +55,15 @@ export default function ApolloConnection(props: Props): JSX.Element {
 
     // https://able.bio/AnasT/apollo-graphql-async-access-token-refresh--470t1c8
     const errorLink: ApolloLink = onError(
-        ({ graphQLErrors, operation, forward }) => {
+        ({ graphQLErrors, networkError, operation, forward }) => {
             if (graphQLErrors) {
                 for (const err of graphQLErrors) {
                     console.error(err);
+                    Toast.show({
+                        text1: t("error.generic"),
+                        text2: err.message,
+                        type: "error",
+                    });
                     switch (err.extensions?.code) {
                         case "UNAUTHENTICATED":
                             // Handle token refresh errors e.g clear stored tokens, redirect to login
@@ -105,6 +114,13 @@ export default function ApolloConnection(props: Props): JSX.Element {
                             break;
                     }
                 }
+            }
+            if (networkError) {
+                Toast.show({
+                    text1: t("error.generic"),
+                    text2: networkError.message,
+                    type: "error",
+                });
             }
         }
     );

--- a/src/screens/AddEditActivityGroup/AddEditActivityGroupScreen.tsx
+++ b/src/screens/AddEditActivityGroup/AddEditActivityGroupScreen.tsx
@@ -265,16 +265,6 @@ const AddEditActivityGroupScreen = (props: Props): JSX.Element => {
                                         color: "black",
                                         fontSize: 25,
                                     }}
-                                    icon={
-                                        <Icon
-                                            style={styles.iconButton}
-                                            name="arrow-right"
-                                            size={15}
-                                            color="black"
-                                            type="font-awesome-5"
-                                        />
-                                    }
-                                    iconRight={true}
                                     onPress={() => handleSubmit()}
                                     loading={loadingCreate || loadingUpdate}
                                 />

--- a/used-libs.md
+++ b/used-libs.md
@@ -9,7 +9,9 @@
 1. react-native-svg
     - [documentation](https://docs.expo.io/versions/latest/sdk/svg/)
     - license: MIT
-
+1. react-native-toast-message
+    - [documentation](https://github.com/calintamas/react-native-toast-message)
+    - license: MIT
 #### Forms and Validation
 
 1. formik


### PR DESCRIPTION
This PR changes:

- optical fixes for update/create activity group button (remove icon)
- Activity Group Header is now pressable everywhere (collapse and expand accordion)
- New message toast library implemented, catches all GraphQL Client errors centrally and displays them so that no error is lost

Screenshot:
![Screen](https://user-images.githubusercontent.com/26229513/116556549-dba2bd80-a8fd-11eb-91ba-891f1b7d51c7.jpg)


Closes #28 