### PR TITLE
Implement missing share button functionality

### DIFF
--- a/src/screens/ShareTrip/ShareTrip.tsx
+++ b/src/screens/ShareTrip/ShareTrip.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { Platform, ScrollView, Share, ShareContent, StyleSheet } from "react-native";
 import { Avatar, Button, Header, Text } from "react-native-elements";
+import Toast from "react-native-toast-message";
 import SvgLogo from "../../components/SvgLogo";
 import { getEnvironment } from "../../get-environment";
 import RootStackParamList from "../../types/RootStackParamList";
@@ -58,8 +59,11 @@ export default function ShareTrip(props: Props): JSX.Element {
 
             await Share.share({ ...shareObject });
         } catch (error) {
-            // TODO - Notify user with error modal
-            console.error(error.message);
+            Toast.show({
+                text1: t("error.generic"),
+                text2: error.message,
+                type: "error",
+            });
         }
     };
 
@@ -97,7 +101,6 @@ export default function ShareTrip(props: Props): JSX.Element {
                     buttonStyle={styles.planTripBtn}
                     title={t("screens.shareTrip.planTrip")}
                     titleStyle={styles.btnTextStyle}
-                    // TODO - Redirect to trip itinerary screen
                     onPress={() =>
                         props.navigation.reset({
                             index: 1,
@@ -108,8 +111,11 @@ export default function ShareTrip(props: Props): JSX.Element {
                                 {
                                     name: Routes.ITINERARY,
                                     params: {
-                                        tripId: props.route.params.trip.id,
-                                        tripName: props.route.params.trip.name,
+                                        screen: Routes.ITINERARY,
+                                        params: {
+                                            tripId: trip.id,
+                                            tripName: trip.name,
+                                        },
                                     },
                                 },
                             ],

--- a/src/services/shareSheetHandler.ts
+++ b/src/services/shareSheetHandler.ts
@@ -1,0 +1,52 @@
+import { FetchResult } from "@apollo/client";
+import { TFunction } from "i18next";
+import { Platform, Share, ShareContent } from "react-native";
+import Toast from "react-native-toast-message";
+import { getEnvironment } from "../get-environment";
+import { CreateInvitationMutation } from "../screens/ShareTrip/types/create-invite.mutation";
+
+export const handleShare = (
+    execute: Promise<FetchResult<CreateInvitationMutation>>,
+    t: TFunction
+): void => {
+    execute
+        .then((result) => {
+            if (result.data?.createInvitation.id) {
+                handleSystemShareSheet(
+                    getEnvironment()?.invitationBaseUrl +
+                        encodeURIComponent(result.data?.createInvitation.id),
+                    t
+                );
+            }
+        })
+        .catch((error) => {
+            Toast.show({
+                text1: t("error.generic"),
+                text2: error.message,
+                type: "error",
+            });
+        });
+};
+
+const handleSystemShareSheet = async (invitationLink: string, t: TFunction): Promise<void> => {
+    try {
+        let shareObject: ShareContent = {
+            title: t("screens.shareTrip.androidShareSheetTitle"),
+            message: invitationLink,
+        };
+        // Only use url to properly display shareable content in iOS share sheet
+        if (Platform.OS === "ios") {
+            shareObject = {
+                url: invitationLink,
+            };
+        }
+
+        await Share.share({ ...shareObject });
+    } catch (error) {
+        Toast.show({
+            text1: t("error.generic"),
+            text2: error.message,
+            type: "error",
+        });
+    }
+};

--- a/src/types/TripTabParamList.ts
+++ b/src/types/TripTabParamList.ts
@@ -8,9 +8,7 @@ type TripTabParamList = {
         };
     };
     [Routes.ITINERARY]: { tripId: string; tripName: string };
-    [Routes.TRIP_SETTINGS]: {
-        tripId: string;
-    };
+    [Routes.TRIP_SETTINGS]: { tripId: string };
 };
 
 export default TripTabParamList;


### PR DESCRIPTION
This PR adds functionality to the share button thats present within the `TripIternary` screen. As discussed, the system share sheet is immediately opened without any custom screens.

Relates to #5 
Closes #62 